### PR TITLE
Added default value to `$actionSegment`

### DIFF
--- a/src/services/RelabelService.php
+++ b/src/services/RelabelService.php
@@ -366,7 +366,7 @@ class RelabelService extends Component
         $request = Craft::$app->getRequest();
 
         $segments = $request->segments;
-        $actionSegment = $segments[count($segments) - 1];
+        $actionSegment = $segments[count($segments) - 1] ?? null;
         if ($actionSegment !== 'get-editor-html' && $actionSegment !== 'switch-entry-type') {
             return false;
         }


### PR DESCRIPTION
AJAX requests to the URI `/admin` result in the following error:
```
PHP Notice 'yii\base\ErrorException' with message 'Undefined offset: -1' 
in /Users/ben/Sites/laloupe.com/vendor/anubarak/craft-relabel/src/services/RelabelService.php:369
```

This pull request fixes this by adding a default value of `null` to `$actionSegment` if the array value is undefined.